### PR TITLE
don't share monero-swap-rpc daemons between syncer instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ use a configuration `.edn` file to configure:
 - `:farcaster-binaries-path` points to the directory containing `farcasterd` and `swap-cli`
 - `:farcaster-config-toml-file` points to the `.toml` file containing your configuration
 
-A sample configuration file can be found [here](./config-sample.edn). The config file's location is passed to `parallel-offer-taker` with the `--config` flag, else assumed to be `./config.edn`.
+A sample configuration file can be found [here](./config-sample.edn). The config file's location is passed to `parallel-offer-taker` with the `--config` flag, else `config-sample.edn` will be read in.
 
 ## usage
 - `clj -M:native-image` or download binary from the latest action build from https://github.com/farcaster-project/parallel-offer-taker/actions/workflows/native-image.yaml?query=branch%3Amain to the directory containing `config.edn`

--- a/config-sample.edn
+++ b/config-sample.edn
@@ -4,4 +4,5 @@
  :data-dir-root nil
  :farcaster-binaries-path nil
  :farcaster-config-toml-file nil
+ :monero-wallet-rpc-binary nil
  }

--- a/deps.edn
+++ b/deps.edn
@@ -9,6 +9,7 @@
                         ;; "--initialize-at-build-time=clojure,clojure.core.server"
                         "--initialize-at-build-time"
                         "--enable-https"
+                        "--enable-http"
                         "--report-unsupported-elements-at-runtime"
                         ;; optional native image name override
                         "-H:Name=parallel-offer-taker"]

--- a/src-dev/manual_funders/manual_btc.clj
+++ b/src-dev/manual_funders/manual_btc.clj
@@ -26,6 +26,4 @@
 
 (comment (electrum "broadcast" (:out (paytomany-output (destination-array)))))
 
-(comment (println (map #(clojure.java.shell/sh "***REMOVED***" "--testnet" "broadcast" %) (map :out outputs))))
-
 (comment (electrum "broadcast" "***REMOVED***"))

--- a/src-dev/manual_funders/manual_xmr.clj
+++ b/src-dev/manual_funders/manual_xmr.clj
@@ -93,7 +93,8 @@
 
 (comment (map splittable-key-images (get (monero-rpc incoming-transfers) "transfers")))
 
-(defn sweep [key-image outputs target-address]
+
+(defn sweep [key-image target-address]
   {"jsonrpc" "2.0",
    "id" "0",
    "method" "sweep_single",

--- a/src-dev/manual_funders/manual_xmr.clj
+++ b/src-dev/manual_funders/manual_xmr.clj
@@ -11,7 +11,7 @@
   ([] (destination-array @destination-file))
   ([destination-file]
    (map
-    (fn [[amount address]] {:amount (bigint (+ (* (Float/parseFloat amount) 1E12) 1E10)) :address address})
+    (fn [[amount address]] {:amount (bigint (* (Float/parseFloat amount) 1E12)) :address address})
     (map #(clojure.string/split % #" ")
          (clojure.string/split-lines (slurp (str "manual_funding" "/" destination-file)))
          ))))

--- a/src-dev/manual_funders/manual_xmr.clj
+++ b/src-dev/manual_funders/manual_xmr.clj
@@ -7,11 +7,14 @@
 
 (def destination-file (atom "default-xmr"))
 
+(defn fixed-float-to-big-int [ff]
+  ((fn [[head tail]] (+ (* (bigint head) 1E12) (bigint tail))) (clojure.string/split ff #"\.")))
+
 (defn destination-array
   ([] (destination-array @destination-file))
   ([destination-file]
    (map
-    (fn [[amount address]] {:amount (bigint (* (Float/parseFloat amount) 1E12)) :address address})
+    (fn [[amount address]] {:amount (fixed-float-to-big-int amount) :address address})
     (map #(clojure.string/split % #" ")
          (clojure.string/split-lines (slurp (str "manual_funding" "/" destination-file)))
          ))))

--- a/src-dev/manual_funders/manual_xmr.clj
+++ b/src-dev/manual_funders/manual_xmr.clj
@@ -8,12 +8,12 @@
 (def destination-file (atom "default-xmr"))
 
 (defn fixed-float-to-big-int [ff]
-  ((fn [[head tail]] (+ (* (bigint head) 1E12)
-                       (bigint (apply str tail (repeat (- 12 (count tail)) "0")))))
+  ((fn [[head tail]] (bigint (+ (* (bigint head) 1E12)
+                               (bigint (apply str tail (repeat (- 12 (count tail)) "0"))))))
    (clojure.string/split ff #"\.")))
 
 (comment
-  (= 3.2358865E11
+  (= 323588650000
      (fixed-float-to-big-int "0.323588650000")
      (fixed-float-to-big-int "0.32358865000")
      (fixed-float-to-big-int "0.32358865")))

--- a/src-dev/manual_funders/manual_xmr.clj
+++ b/src-dev/manual_funders/manual_xmr.clj
@@ -8,7 +8,13 @@
 (def destination-file (atom "default-xmr"))
 
 (defn fixed-float-to-big-int [ff]
-  ((fn [[head tail]] (+ (* (bigint head) 1E12) (bigint tail))) (clojure.string/split ff #"\.")))
+  ((fn [[head tail]] (+ (* (bigint head) 1E12) (bigint (apply str tail (repeat (- 12 (count tail)) "0"))))) (clojure.string/split ff #"\.")))
+
+(comment
+  (= 3.2358865E11
+     (fixed-float-to-big-int "0.323588650000")
+     (fixed-float-to-big-int "0.32358865000")
+     (fixed-float-to-big-int "0.32358865")))
 
 (defn destination-array
   ([] (destination-array @destination-file))

--- a/src-dev/manual_funders/manual_xmr.clj
+++ b/src-dev/manual_funders/manual_xmr.clj
@@ -8,12 +8,12 @@
 (def destination-file (atom "default-xmr"))
 
 (defn destination-array
-  ([] (destination-array destination-file))
+  ([] (destination-array @destination-file))
   ([destination-file]
    (map
     (fn [[amount address]] {:amount (bigint (+ (* (Float/parseFloat amount) 1E12) 1E10)) :address address})
     (map #(clojure.string/split % #" ")
-         (clojure.string/split-lines (slurp (str "manual_funding" "/" @destination-file)))
+         (clojure.string/split-lines (slurp (str "manual_funding" "/" destination-file)))
          ))))
 
 (def get-balance

--- a/src-dev/manual_funders/manual_xmr.clj
+++ b/src-dev/manual_funders/manual_xmr.clj
@@ -8,7 +8,9 @@
 (def destination-file (atom "default-xmr"))
 
 (defn fixed-float-to-big-int [ff]
-  ((fn [[head tail]] (+ (* (bigint head) 1E12) (bigint (apply str tail (repeat (- 12 (count tail)) "0"))))) (clojure.string/split ff #"\.")))
+  ((fn [[head tail]] (+ (* (bigint head) 1E12)
+                       (bigint (apply str tail (repeat (- 12 (count tail)) "0")))))
+   (clojure.string/split ff #"\.")))
 
 (comment
   (= 3.2358865E11

--- a/src/parallel_offer_taker/core.clj
+++ b/src/parallel_offer_taker/core.clj
@@ -377,6 +377,7 @@
   (let [{:keys [start-range end-range options exit-message ok?]} (validate-args args)]
     (if exit-message
       (exit (if ok? 0 1) exit-message)
+      #_{:clj-kondo/ignore [:missing-else-branch]}
       (if (validate-config options)
         (runner start-range end-range options))
       )))

--- a/src/parallel_offer_taker/core.clj
+++ b/src/parallel_offer_taker/core.clj
@@ -98,7 +98,7 @@
     (map #(if (clojure.core/re-find #"^farcasterd.auto_funding*" %)
             %
             (clojure.string/replace %
-             #"monero_rpc_wallet = (\D+)(\d+)" (str "monero_rpc_wallet = $1" (monero-wallet-rpc-port swap-index config)))
+                                    #"monero_rpc_wallet = (\D+)(\d+)" (str "monero_rpc_wallet = $1" (monero-wallet-rpc-port swap-index config)))
             ) data)
     (clojure.string/join "[" data)
     (spit (swap-specific-toml-path swap-index config) data)

--- a/src/parallel_offer_taker/core.clj
+++ b/src/parallel_offer_taker/core.clj
@@ -373,7 +373,7 @@
     (println "offers: " @offers)
 
     ;; unless can restore past swap(s), take offer(s)
-    ;; (doall (map #(restore-or-offer-take % config) (range min-swap-index (min max-swap-index (+ min-swap-index (dec (count @offers)))))))
+    (doall (map #(restore-or-offer-take % config) (range min-swap-index (min max-swap-index (+ min-swap-index (dec (count @offers)))))))
 
     ;; keep alive
     (while true (do

--- a/src/parallel_offer_taker/core.clj
+++ b/src/parallel_offer_taker/core.clj
@@ -187,11 +187,11 @@
              ]
             (clojure.string/split (:monero-wallet-rpc-options config) #" "))))
 
-(defn append-logging [swap-index config farcasterd-launch-vec]
+(defn append-logging [swap-index config binary-launch-vec]
   (concat
-   farcasterd-launch-vec
+   binary-launch-vec
    ["1>>"
-    (str (add-missing-trailing-slash (:data-dir-root config)) "farcasterd_" swap-index ".log")
+    (str (add-missing-trailing-slash (:data-dir-root config)) (first binary-launch-vec) "_" swap-index ".log")
     "2>&1"
     "&"
     "\n"

--- a/src/parallel_offer_taker/core.clj
+++ b/src/parallel_offer_taker/core.clj
@@ -351,6 +351,7 @@
         )
       (do
         (println "following daemons aren't responding, launching them first:" unresponsive-daemons)
+        (doall (map #(spit-swap-specific-toml % config) unresponsive-daemons))
         (doall (map #(launch-process :farcasterd % config) unresponsive-daemons))))
 
     ;; ensure all monero-wallet-rpcs are listening
@@ -360,8 +361,7 @@
         )
       (do
         (println "following rpc daemons aren't responding, launching them first:" unresponsive-xmr-wallet-rpcs)
-        (doall (map #(spit-swap-specific-toml % config) unresponsive-xmr-wallet-rpcs)
-)
+
         (doall
          (map #(launch-process :monero-wallet-rpc % config) unresponsive-xmr-wallet-rpcs))))
 

--- a/src/parallel_offer_taker/core.clj
+++ b/src/parallel_offer_taker/core.clj
@@ -377,7 +377,7 @@
 
     ;; keep alive
     (while true (do
-                  (Thread/sleep 10000)
+                  (Thread/sleep 60000)
                   (let [running-swaps (map
                                        (fn [idx] {:farcaster-id idx :swap-ids (list-running-swaps idx config)})
                                        (range min-swap-index max-swap-index))
@@ -400,6 +400,7 @@
                                  "running swaps:"
                                  {
                                   :details (filter #(seq (:swap-ids %)) running-swaps)
+                                  :farcasterd-running (map #(farcasterd-running? (:farcaster-id %) config) running-swaps)
                                   :count
                                   (->> running-swaps
                                        (map :swap-ids)

--- a/src/parallel_offer_taker/core.clj
+++ b/src/parallel_offer_taker/core.clj
@@ -206,20 +206,23 @@
             (clojure.string/split (:monero-wallet-rpc-options config) #" ")))
 
 (defn append-logging [swap-index config binary-launch-vec]
-  (concat
-   binary-launch-vec
-   ["1>>"
-    (str (add-missing-trailing-slash (:data-dir-root config)) (first binary-launch-vec) "_" swap-index ".log")
-    "2>&1"
-    "&"
-    "\n"
-    "echo"
-    "$!"
-    ]))
+  (let [binary-name (-> binary-launch-vec
+                        first
+                        (clojure.string/split #"/")
+                        last)]
+    (concat
+     binary-launch-vec
+     ["1>>"
+      (str (add-missing-trailing-slash (:data-dir-root config)) binary-name "_" swap-index ".log")
+      "2>&1"
+      "&"
+      "\n"
+      "echo"
+      "$!"
+      ])))
 
 (defn farcasterd-process-id-exact [swap-index config]
-  (try (->> ["bash" "-c" (str "ps -ef | grep \"" (string/join " " (farcasterd-launch-vec swap-index config)) "$\" | grep -v grep | awk '{print $2}'"
-                              )]
+  (try (->> ["bash" "-c" (str "ps -ef | grep \"" (string/join " " (farcasterd-launch-vec swap-index config)) "$\" | grep -v grep | awk '{print $2}'")]
             (apply shell/sh)
             :out
             string/trim-newline

--- a/src/parallel_offer_taker/core.clj
+++ b/src/parallel_offer_taker/core.clj
@@ -355,7 +355,9 @@
         )
       (do
         (println "following rpc daemons aren't responding, launching them first:" unresponsive-xmr-wallet-rpcs)
-        (doall (map #(launch-process :monero-wallet-rpc % config) unresponsive-xmr-wallet-rpcs))))
+        (doall
+         (map #(spit-swap-specific-toml % config) unresponsive-xmr-wallet-rpcs)
+         (map #(launch-process :monero-wallet-rpc % config) unresponsive-xmr-wallet-rpcs))))
 
     ;; get offers
     (reset! offers (offers-get))

--- a/src/parallel_offer_taker/core.clj
+++ b/src/parallel_offer_taker/core.clj
@@ -344,6 +344,9 @@
     (println "swap index range:" min-swap-index max-swap-index)
     (println "config:" config)
 
+    (println "creating config per swap")
+    (doall (map #(spit-swap-specific-toml % config) (range min-swap-index max-swap-index)))
+
     ;; ensure all daemons running
     (if (empty? unresponsive-daemons)
       (do
@@ -351,7 +354,6 @@
         )
       (do
         (println "following daemons aren't responding, launching them first:" unresponsive-daemons)
-        (doall (map #(spit-swap-specific-toml % config) unresponsive-daemons))
         (doall (map #(launch-process :farcasterd % config) unresponsive-daemons))))
 
     ;; ensure all monero-wallet-rpcs are listening

--- a/src/parallel_offer_taker/core.clj
+++ b/src/parallel_offer_taker/core.clj
@@ -65,6 +65,27 @@
   (or (:monero-wallet-rpc-binary config)
       "monero-wallet-rpc"))
 
+(defn monero-wallet-rpc-port [swap-index config]
+  (+ swap-index (:monero-wallet-rpc-start-rpc-port config)))
+
+(defn monero-wallet-rpc-url [swap-index config]
+  (let [rpc-port (monero-wallet-rpc-port swap-index config)]
+    (str "http://127.0.0.1:" rpc-port "/json_rpc")))
+
+(def get-version
+  (json/write-str
+   {"jsonrpc" "2.0",
+    "id" "0",
+    "method" "get_version",
+    }))
+
+(defn monero-wallet-rpc-running? [swap-index config]
+  (let [rpc-url (monero-wallet-rpc-url swap-index config)]
+    (try (some? (:body (http/get rpc-url {:body get-version})))
+         (catch Exception e
+           (println (:cause (Throwable->map e)))
+           false))))
+
 (defn farcaster-template-config-toml-file [config]
   (or (:farcaster-config-toml-file config) "~/.farcaster/farcaster.toml"))
 
@@ -181,26 +202,8 @@
                         false))
         false)))
 
-(def get-version
-  (json/write-str
-   {"jsonrpc" "2.0",
-    "id" "0",
-    "method" "get_version",
-    }))
 
-(defn monero-wallet-rpc-port [swap-index config]
-  (+ swap-index (:monero-wallet-rpc-start-rpc-port config)))
 
-(defn monero-wallet-rpc-url [swap-index config]
-  (let [rpc-port (monero-wallet-rpc-port swap-index config)]
-    (str "http://127.0.0.1:" rpc-port "/json_rpc")))
-
-(defn monero-wallet-rpc-running? [swap-index config]
-  (let [rpc-url (monero-wallet-rpc-url swap-index config)]
-    (try (some? (:body (http/get rpc-url {:body get-version})))
-         (catch Exception e
-           (println (:cause (Throwable->map e)))
-           false))))
 
 (comment (farcasterd-running? 0 (read-config "config.edn")))
 

--- a/src/parallel_offer_taker/core.clj
+++ b/src/parallel_offer_taker/core.clj
@@ -373,15 +373,16 @@
     (println "offers: " @offers)
 
     ;; unless can restore past swap(s), take offer(s)
-    (doall (map #(restore-or-offer-take % config) (range min-swap-index (min max-swap-index (+ min-swap-index (dec (count @offers)))))))
+    ;; (doall (map #(restore-or-offer-take % config) (range min-swap-index (min max-swap-index (+ min-swap-index (dec (count @offers)))))))
 
     ;; keep alive
     (while true (do
-                  (Thread/sleep 30000)
+                  (Thread/sleep 10000)
                   (let [running-swaps (map
                                        (fn [idx] {:farcaster-id idx :swap-ids (list-running-swaps idx config)})
                                        (range min-swap-index max-swap-index))
-                        idle-farcasterds (filter #(and (empty? (:swap-ids %)) (farcasterd-running? (:farcaster-id %) config)) running-swaps)]
+                        idle-farcasterds (filter #(and (empty? (:swap-ids %)) ;; (farcasterd-running? (:farcaster-id %) config)
+                                                       ) running-swaps)]
                     (if (:sustain options)
                       ;; if user wants to sustain swap quantity, take another offer
                        (do

--- a/src/parallel_offer_taker/core.clj
+++ b/src/parallel_offer_taker/core.clj
@@ -382,14 +382,18 @@
                                "running swaps:"
                                (let [running-swaps (map
                                                     (fn [idx] {:farcaster-id idx :swap-ids (list-running-swaps idx config)})
-                                                    (range min-swap-index (min max-swap-index (+ min-swap-index (dec (count @offers))))))
+                                                    (range min-swap-index max-swap-index))
                                      idle-farcasterds (filter #(and (empty? (:swap-ids %)) (farcasterd-running? (:farcaster-id %) config)) running-swaps)]
                                  (if (:sustain options)
                                    ;; if user wants to sustain swap quantity, take another offer
-                                   (do (reset! offers (offers-get))
-                                       (doall (map #(restore-or-offer-take (:farcaster-id %) config) idle-farcasterds)))
+                                   (do
+                                     (println "retrieving new offers")
+                                     (reset! offers (offers-get))
+                                     (doall (map #(restore-or-offer-take (:farcaster-id %) config) idle-farcasterds)))
                                    ;; else kill the daemon
-                                   (doall (map #(kill-farcasterd (:farcaster-id %) config) idle-farcasterds)))
+                                   (do
+                                     (println "killing daemon")
+                                     (doall (map #(kill-farcasterd (:farcaster-id %) config) idle-farcasterds))))
                                  {
                                   :details (filter #(seq (:swap-ids %)) running-swaps)
                                   :count

--- a/src/parallel_offer_taker/core.clj
+++ b/src/parallel_offer_taker/core.clj
@@ -51,11 +51,11 @@
       (catch Exception e
         (println e)))))
 
-(defn binary-dir [config]
+(defn farcaster-binary-dir [config]
   (or (add-missing-trailing-slash (:farcaster-binaries-path config)) "~/.cargo/bin/"))
 
-(defn binary-path [config binary-name]
-  (str (binary-dir config) binary-name))
+(defn farcaster-binary-path [config binary-name]
+  (str (farcaster-binary-dir config) binary-name))
 
 (defn farcaster-config-toml-file [config]
   (or (:farcaster-config-toml-file config) "~/.farcaster/farcaster.toml"))
@@ -69,7 +69,7 @@
 (comment (help))
 
 (defn offer-take [swap-index config]
-  (let [result (apply shell/sh [(binary-path config "swap-cli")
+  (let [result (apply shell/sh [(farcaster-binary-path config "swap-cli")
                                 "-d" (data-dir swap-index config)
                                 "take" "-w"
                                 "--btc-addr" (:address-btc config)
@@ -79,7 +79,7 @@
     ))
 
 (defn list-running-swaps [swap-index config]
-  (let [result (apply shell/sh [(binary-path config "swap-cli")
+  (let [result (apply shell/sh [(farcaster-binary-path config "swap-cli")
                                 "-d" (data-dir swap-index config)
                                 "ls"])]
     (-> (:out result)
@@ -87,7 +87,7 @@
     ))
 
 (defn list-checkpoints [swap-index config]
-  (let [result (apply shell/sh [(binary-path config "swap-cli")
+  (let [result (apply shell/sh [(farcaster-binary-path config "swap-cli")
                                 "-d" (data-dir swap-index config)
                                 "list-checkpoints"])]
     (-> (:out result)
@@ -95,7 +95,7 @@
     ))
 
 (defn list-swaps [swap-index config]
-  (let [result (apply shell/sh [(binary-path config "swap-cli")
+  (let [result (apply shell/sh [(farcaster-binary-path config "swap-cli")
                                 "-d" (data-dir swap-index config)
                                 "list-swaps"])]
     (-> (:out result)
@@ -105,7 +105,7 @@
 (defn restore-all-checkpoints [swap-index config]
   (let [checkpoints (map :swap_id (list-checkpoints swap-index config))
         results (map (fn [checkpoint]
-                       (apply shell/sh [(binary-path config "swap-cli")
+                       (apply shell/sh [(farcaster-binary-path config "swap-cli")
                                         "-d" (data-dir swap-index config)
                                         "restore-checkpoint" checkpoint]))
                      checkpoints)]
@@ -151,7 +151,7 @@
   (let [data-dir (data-dir swap-index config)]
     (if data-dir (try (-> (apply shell/sh
                                  [
-                                  (str (binary-dir config) "swap-cli")
+                                  (str (farcaster-binary-dir config) "swap-cli")
                                   "-d" data-dir
                                   "info"
                                   ])
@@ -167,7 +167,7 @@
 (defn farcasterd-launch-vec [swap-index config]
   (let [data-dir (data-dir swap-index config)]
     [
-     (str (binary-dir config) "farcasterd")
+     (str (farcaster-binary-dir config) "farcasterd")
      "-c" (farcaster-config-toml-file config)
      "-d" data-dir
      ]))
@@ -247,7 +247,7 @@
 (defn progress [swap-index config]
   (let [swaps (list-swaps swap-index config)
         results (map (fn [swap]
-                      (apply shell/sh [(binary-path config "swap-cli")
+                      (apply shell/sh [(farcaster-binary-path config "swap-cli")
                                        "-d" (data-dir swap-index config)
                                        "progress" swap]))
                     swaps)]

--- a/src/parallel_offer_taker/core.clj
+++ b/src/parallel_offer_taker/core.clj
@@ -341,7 +341,11 @@
       {:exit-message (error-msg errors)}
       ;; custom validation on arguments
       (and (= 2 (count arguments))
-           (every? (fn [arg] (every? #(Character/isDigit %) arg)) arguments))
+           (every? (fn [arg] (try (Integer/parseInt arg)
+                                 (catch Exception e
+                                   ;; TODO: cleaner return - cause alone here not sufficient, and rest too verbose
+                                   (println "failure parsing" arg "as integer:" e))))
+                   arguments))
       {:start-range (Integer/parseInt (first arguments))
        :end-range (Integer/parseInt (second arguments))
        :options options}

--- a/src/parallel_offer_taker/core.clj
+++ b/src/parallel_offer_taker/core.clj
@@ -177,9 +177,12 @@
     "method" "get_version",
     }))
 
+(defn monero-wallet-rpc-url [swap-index config]
+  (let [rpc-port (+ swap-index (:monero-wallet-rpc-start-rpc-port config))]
+   (str "http://127.0.0.1:" rpc-port "/json_rpc")))
+
 (defn monero-wallet-rpc-running? [swap-index config]
-  (let [rpc-port (+ swap-index (:monero-wallet-rpc-start-rpc-port config))
-        rpc-url (str "http://127.0.0.1:" rpc-port "/json_rpc")]
+  (let [rpc-url (monero-wallet-rpc-url swap-index config)]
     (try (some? (:body (http/get rpc-url {:body get-version})))
          (catch Exception e
            (println (:cause (Throwable->map e)))
@@ -192,6 +195,7 @@
     [
      (str (farcaster-binary-dir config) "farcasterd")
      "-c" (farcaster-config-toml-file config)
+     "--monero-wallet-rpc" (monero-wallet-rpc-url swap-index config)
      "-d" data-dir
      ]))
 

--- a/src/parallel_offer_taker/core.clj
+++ b/src/parallel_offer_taker/core.clj
@@ -274,7 +274,7 @@
 (def process-ids (atom {}))
 
 (defn launch-process [process swap-index config]
-  (if (not  (or (contains? @process-ids swap-index)
+  (if (not  (or (contains? @process-ids (keyword (str process "-" swap-index)))
                 (process-id-exact process swap-index config)))
     (->> config
          ((process-launch-vec process) swap-index)

--- a/src/parallel_offer_taker/core.clj
+++ b/src/parallel_offer_taker/core.clj
@@ -57,6 +57,10 @@
 (defn farcaster-binary-path [config binary-name]
   (str (farcaster-binary-dir config) binary-name))
 
+(defn monero-wallet-rpc-binary [config]
+  (or (:monero-wallet-rpc-binary config)
+      "monero-wallet-rpc"))
+
 (defn farcaster-config-toml-file [config]
   (or (:farcaster-config-toml-file config) "~/.farcaster/farcaster.toml"))
 
@@ -171,6 +175,17 @@
      "-c" (farcaster-config-toml-file config)
      "-d" data-dir
      ]))
+
+(defn monero-wallet-rpc-launch-vec [swap-index config]
+  (let [data-dir-root (:data-dir-root config)]
+    (concat [
+             (monero-wallet-rpc-binary config)
+             "--rpc-bind-port" (+
+                                (:monero-wallet-rpc-start-rpc-port config)
+                                swap-index)
+             "--wallet-dir" (str data-dir-root "syncer_wallets_" swap-index)
+             ]
+            (clojure.string/split (:monero-wallet-rpc-options config) #" "))))
 
 (defn append-logging [swap-index config farcasterd-launch-vec]
   (concat

--- a/src/parallel_offer_taker/core.clj
+++ b/src/parallel_offer_taker/core.clj
@@ -304,7 +304,7 @@
 
 (def cli-options
   [["-c" "--config CONFIG" "Config file"
-    :default "config.edn"
+    :default (read-config "config-sample.edn")
     :parse-fn #(read-config %)]
    ;; ["-v" nil "Verbosity level"
    ;;  :id :verbosity

--- a/src/parallel_offer_taker/core.clj
+++ b/src/parallel_offer_taker/core.clj
@@ -355,8 +355,9 @@
         )
       (do
         (println "following rpc daemons aren't responding, launching them first:" unresponsive-xmr-wallet-rpcs)
+        (doall (map #(spit-swap-specific-toml % config) unresponsive-xmr-wallet-rpcs)
+)
         (doall
-         (map #(spit-swap-specific-toml % config) unresponsive-xmr-wallet-rpcs)
          (map #(launch-process :monero-wallet-rpc % config) unresponsive-xmr-wallet-rpcs))))
 
     ;; get offers

--- a/src/parallel_offer_taker/core.clj
+++ b/src/parallel_offer_taker/core.clj
@@ -383,9 +383,9 @@
                                        (range min-swap-index max-swap-index))
                         idle-farcasterds (filter #(and (empty? (:swap-ids %)) ;; (farcasterd-running? (:farcaster-id %) config)
                                                        ) running-swaps)]
-                    (if (:sustain options)
+                    (if (and (:sustain options) (seq idle-farcasterds))
                       ;; if user wants to sustain swap quantity, take another offer
-                       (do
+                      (do
                         (println "idle-farcasterds:" idle-farcasterds)
                         (println "retrieving new offers")
                         (reset! offers (offers-get))


### PR DESCRIPTION
syncer interface not designed for concurrency (and neither is monero-swap-rpc, to my knowledge): responses sometimes relayed to the wrong swap. could launch all swaps from a single farcasterd instance, but still want to test handling of multiple peers on the maker's part. so should change input parameter from $|instances|$ to $|instances| \times swaps_{instance}$